### PR TITLE
Better solution for Add Two Numbers

### DIFF
--- a/0002-add_two_numbers/README.md
+++ b/0002-add_two_numbers/README.md
@@ -2,15 +2,16 @@
 
 Solution Details: https://readreplica.io/leetcode-add-two-numbers-elixir-solution/
 
-Given two sorted arrays nums1 and nums2 of size m and n respectively, return the median of the two sorted arrays.
+You are given two non-empty linked lists representing two non-negative integers. The digits are stored in reverse order, and each of their nodes contains a single digit.
 
-The overall run time complexity should be O(log (m+n)).
+Add the two numbers and return the sum as a linked list.
+
+You may assume the two numbers do not contain any leading zero, except the number 0 itself.
+
+The overall run time complexity should be O(max(m,n)).
 
 Constraints:
 
-    nums1.length == m
-    nums2.length == n
-    0 <= m <= 1000
-    0 <= n <= 1000
-    1 <= m + n <= 2000
-    -106 <= nums1[i], nums2[i] <= 106
+* The number of nodes in each linked list is in the range [1, 100].
+* 0 <= Node.val <= 9
+* It is guaranteed that the list represents a number that does not have leading zeros.

--- a/0002-add_two_numbers/lib/add_two_numbers.ex
+++ b/0002-add_two_numbers/lib/add_two_numbers.ex
@@ -1,9 +1,8 @@
 defmodule AddTwoNumbers do
   @moduledoc """
-  1. Convert Linked List to Integer (already reversed)
-  2. Split sum into list: [1, 2, 3]
-  3. Reverse list
-  4. Re-build linked list result using recursion.
+  Add ones, then tens, etc and don't forget about carrying.
+
+  Complexity: O(max(n,m))
   """
 
   @spec calc([integer], [integer]) :: [integer]

--- a/0002-add_two_numbers/lib/add_two_numbers.ex
+++ b/0002-add_two_numbers/lib/add_two_numbers.ex
@@ -5,31 +5,36 @@ defmodule AddTwoNumbers do
   3. Reverse list
   4. Re-build linked list result using recursion.
   """
-  @spec add_two_numbers(l1 :: ListNode.t() | nil, l2 :: ListNode.t() | nil) :: ListNode.t() | nil
-  def add_two_numbers(l1, l2) do
-    total = 0
-    exponent = 1
-    value1 = list_to_integer(l1, total, exponent)
-    value2 = list_to_integer(l2, total, exponent)
 
-    (value1 + value2)
-    |> Integer.digits()
-    |> Enum.reverse()
-    |> to_linked_list()
+  @spec calc([integer], [integer]) :: [integer]
+  def calc(a, b) do
+    do_calc(a, b, 0, []) |> Enum.reverse()
   end
 
-  defp list_to_integer(nil, total, _), do: total
+  defp do_calc([], [], 0, result), do: result
+  defp do_calc([], [], 1, result), do: [1 | result]
 
-  defp list_to_integer(node, total, exponent) do
-    %ListNode{val: current_value, next: next_node} = node
-    new_total = total + current_value * exponent
-    new_exponent = exponent * 10
-    list_to_integer(next_node, new_total, new_exponent)
+  defp do_calc([a | as], [], carry, result) do
+    {sum, new_carry} = add_with_carry(a, 0, carry)
+
+    do_calc([], as, new_carry, [sum | result])
   end
 
-  defp to_linked_list([]), do: nil
+  defp do_calc([], [b | bs], carry, result) do
+    {sum, new_carry} = add_with_carry(0, b, carry)
 
-  defp to_linked_list([h | tail]) do
-    %ListNode{val: h, next: to_linked_list(tail)}
+    do_calc([], bs, new_carry, [sum | result])
+  end
+
+  defp do_calc([a | as], [b | bs], carry, result) do
+    {sum, new_carry} = add_with_carry(a, b, carry)
+
+    do_calc(as, bs, new_carry, [sum | result])
+  end
+
+  defp add_with_carry(a, b, carry) do
+    sum = (a + b + carry)
+
+    if sum >= 10, do: {sum - 10, 1}, else: {sum, 0}
   end
 end

--- a/0002-add_two_numbers/lib/list_node.ex
+++ b/0002-add_two_numbers/lib/list_node.ex
@@ -1,7 +1,0 @@
-defmodule ListNode do
-  @type t :: %__MODULE__{
-          val: integer,
-          next: ListNode.t() | nil
-        }
-  defstruct val: 0, next: nil
-end

--- a/0002-add_two_numbers/test/add_two_numbers_test.exs
+++ b/0002-add_two_numbers/test/add_two_numbers_test.exs
@@ -1,67 +1,13 @@
 defmodule AddTwoNumbersTest do
   use ExUnit.Case
-  import AddTwoNumbers
 
-  test "adds 3-digit lists" do
-    l1 = %ListNode{next: %ListNode{next: %ListNode{next: nil, val: 3}, val: 4}, val: 2}
-    l2 = %ListNode{next: %ListNode{next: %ListNode{next: nil, val: 4}, val: 6}, val: 5}
+  import AddTwoNumbers, only: [calc: 2]
 
-    assert add_two_numbers(l1, l2) == %ListNode{
-             val: 7,
-             next: %ListNode{val: 0, next: %ListNode{val: 8, next: nil}}
-           }
-  end
-
-  test "adds zero lists" do
-    l1 = %ListNode{next: nil, val: 0}
-    l2 = %ListNode{next: nil, val: 0}
-    assert add_two_numbers(l1, l2) == %ListNode{val: 0, next: nil}
-  end
-
-  test "adds 9s lists" do
-    l1 = %ListNode{
-      next: %ListNode{
-        next: %ListNode{
-          next: %ListNode{
-            next: %ListNode{
-              next: %ListNode{next: %ListNode{next: nil, val: 9}, val: 9},
-              val: 9
-            },
-            val: 9
-          },
-          val: 9
-        },
-        val: 9
-      },
-      val: 9
-    }
-
-    l2 = %ListNode{
-      next: %ListNode{
-        next: %ListNode{next: %ListNode{next: nil, val: 9}, val: 9},
-        val: 9
-      },
-      val: 9
-    }
-
-    assert add_two_numbers(l1, l2) == %ListNode{
-             val: 8,
-             next: %ListNode{
-               val: 9,
-               next: %ListNode{
-                 val: 9,
-                 next: %ListNode{
-                   val: 9,
-                   next: %ListNode{
-                     val: 0,
-                     next: %ListNode{
-                       val: 0,
-                       next: %ListNode{val: 0, next: %ListNode{val: 1, next: nil}}
-                     }
-                   }
-                 }
-               }
-             }
-           }
+  test ".calc/2" do
+    assert calc([1], [2]) == [3]
+    assert calc([5], [5]) == [0,1]
+    assert calc([2,4,3], [5,6,4]) == [7,0,8]                     # 342 + 465 = 807
+    assert calc([0,0,1], [1,1]) == [1,1,1]                       # 100 + 11 = 111
+    assert calc([9,9,9,9,9,9,9], [9,9,9,9]) == [8,9,9,9,0,0,0,1] # 9,999,999 + 9,999 = 10,009,998
   end
 end


### PR DESCRIPTION
Hey, @tmartin8080!

Saw your blog in ElixirWeekly, thanks for sharing your knowledge!

I want to propose better solution for Add Two Numbers problem. Instead of converting each input from list to integer, adding integers and then converting result back to list again we can just add them using column method: add ones, then add tens, etc. This way we can get result in a single `O(max(n,m))` go.

I also think `%ListNode{}` structure isn't needed there. Lists in Elixir are implemented as linked lists, so simple `[1,2,3]` list will do. I think the point here is not to use specific suggested struct, but rather to iterate over lists using recursion and/or pattern matching instead of usual array-with-index-loop.

P.S. I also fixed README file, it seems to describe a different problem.

Cheers!